### PR TITLE
Fix Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ go get github.com/badoet/go-xfers
 ####### Standard Go Usage (EXAMPLE)
 ```go
 import (
-  xfers "github.com/badoet/go-xfers"
+   "github.com/badoet/go-xfers"
 )
 
 var XfersAPI *xfers.XfersClient


### PR DESCRIPTION
The package name is `xfers` so there is no need to add a named import because `xfers` is what wil be imported.
